### PR TITLE
add support for partial reconcile

### DIFF
--- a/base_upflow/models/__init__.py
+++ b/base_upflow/models/__init__.py
@@ -1,6 +1,6 @@
 from . import upflow_mixin
 from . import (
-    account_full_reconcile,
+    account_reconcile,
     account_journal,
     account_move,
     account_payment,

--- a/base_upflow/models/account_move.py
+++ b/base_upflow/models/account_move.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 import base64
 
-from odoo import _,fields, models
+from odoo import _, fields, models
 from odoo.exceptions import UserError
 
 
@@ -22,9 +22,9 @@ class AccountMove(models.Model):
         # there are chance that partner_id is not set on account.move
         # so we try to get the information on first receivable account.move.line
         for move in self:
-            self.upflow_commercial_partner_id = (
-                self.partner_id.commercial_partner_id
-                or self.line_ids.filtered(
+            move.upflow_commercial_partner_id = (
+                move.partner_id.commercial_partner_id
+                or move.line_ids.filtered(
                     lambda line: line.account_id.user_type_id.type == "receivable"
                 ).partner_id.commercial_partner_id
             )

--- a/base_upflow/tests/test_account_move.py
+++ b/base_upflow/tests/test_account_move.py
@@ -1,5 +1,6 @@
 from odoo.tests.common import SavepointCase
 
+
 class TestAccountMove(SavepointCase):
     @classmethod
     def setUpClass(cls):
@@ -14,10 +15,19 @@ class TestAccountMove(SavepointCase):
             {"name": "Test product", "type": "service"}
         )
         cls.account_user_type = cls.env["account.account.type"].create(
-            {"name": "Test account type", "type": "receivable", "internal_group": "asset"}
+            {
+                "name": "Test account type",
+                "type": "receivable",
+                "internal_group": "asset",
+            }
         )
         cls.account = cls.env["account.account"].create(
-            {"name": "Test account", "code": "TEST", "user_type_id": cls.account_user_type.id, "reconcile": True}
+            {
+                "name": "Test account",
+                "code": "TEST",
+                "user_type_id": cls.account_user_type.id,
+                "reconcile": True,
+            }
         )
         cls.entry_move = cls.env["account.move"].create(
             {
@@ -47,7 +57,13 @@ class TestAccountMove(SavepointCase):
         )
 
     def test_compute_upflow_commercial_partner_id_entry(self):
-        self.assertEqual(self.entry_move.upflow_commercial_partner_id, self.partner.commercial_partner_id)
+        self.assertEqual(
+            self.entry_move.upflow_commercial_partner_id,
+            self.partner.commercial_partner_id,
+        )
 
     def test_compute_upflow_commercial_partner_id_invoice(self):
-        self.assertEqual(self.account_move.upflow_commercial_partner_id, self.partner.commercial_partner_id)
+        self.assertEqual(
+            self.account_move.upflow_commercial_partner_id,
+            self.partner.commercial_partner_id,
+        )


### PR DESCRIPTION
- refactor code of `account.full.reconcile` for it to be used for `account.partial.reconcile` (using an abstract model)
- fix pre-commit
- fix code https://github.com/petrus-v/credit-control/pull/3/files#diff-be179d4addb63f23dbb324a3ad5e9c46fcccff7a05ee1cd6a3ea27ae5e697963R25-R27 to use loop variable `move` instead of `self` 😬 